### PR TITLE
feat: remove is_non_localizable property from unsupported type elements in MAPI

### DIFF
--- a/lib/models/elements/content-type-element.models.ts
+++ b/lib/models/elements/content-type-element.models.ts
@@ -69,7 +69,6 @@ export namespace ContentTypeElements {
         snippet: SharedContracts.IReferenceObjectContract;
         type: 'snippet';
         external_id?: string;
-        is_non_localizable?: boolean;
     }
 
     export interface ICustomElementData extends IElementShared {
@@ -105,7 +104,6 @@ export namespace ContentTypeElements {
         type: 'guidelines';
         codename?: string;
         external_id?: string;
-        is_non_localizable?: boolean;
     }
 
     export interface ILinkedItemsElementData extends IElementShared {

--- a/test/browser/fake-responses/content-types/fake-list-content-types.json
+++ b/test/browser/fake-responses/content-types/fake-list-content-types.json
@@ -26,8 +26,7 @@
             "guidelines": "",
             "type": "guidelines",
             "id": "9367da14-3d08-4ed1-4841-24bf8055f916",
-            "codename": "n9367da14_3d08_4ed1_4841_24bf8055f916",
-            "is_non_localizable": false
+            "codename": "n9367da14_3d08_4ed1_4841_24bf8055f916"
           },
           {
             "name": "Hero unit",
@@ -59,8 +58,7 @@
             },
             "type": "snippet",
             "id": "255d6748-ba3a-1b59-af5c-afd4a7d6cb4f",
-            "codename": "metadata",
-            "is_non_localizable": false
+            "codename": "metadata"
           }
         ]
       }


### PR DESCRIPTION
### Motivation
Which issue does this fix? Fixes #KCL-9904

We decided to remove `is_non_localizable` property from all type elements which are not supported and will not be supported in the future before we release this feature publicly in December (currently this feature is in early access). The type elements that **should not** have this property are **snippet element** and **guidelines element**.

After discussion with @Simply007 we decided that this can be released as a new minor version because non-localizable elements are still in early access. But we can discuss it further if you think it should be considered a breaking change and released as a new major version.

### Checklist

- [X] Code follows coding conventions held in this repo
- [X] Automated tests have been added
- [X] Tests are passing
- [X] Docs have been updated (if applicable)
- [X] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

