### PR TITLE
added id field to type object in IAddContentItemPostContract and made codename and id fields nullable

### DIFF
--- a/lib/contracts/content-item-contracts.ts
+++ b/lib/contracts/content-item-contracts.ts
@@ -50,7 +50,8 @@ export namespace ContentItemContracts {
     export interface IAddContentItemPostContract {
         name: string;
         type: {
-            codename: string
+            codename?: string,
+            id?: string
         };
         codename?: string;
         external_id?: string;


### PR DESCRIPTION

### Motivation

Which issue does this fix? Fixes #89 
I'm not sure if there is a better solution than making both id and codename field nullable. I checked and passing neither when adding an item gives "invalid request body" error so I think its okay.

### Checklist

- [✔ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [✔ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [✔ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test
Automated tests: npm run test: all

Manual live client tests:
Create tarball with npm pack
Add tarball to testing project and update MAPI dependency to reference it
Install packages
Perform test requests with live project
