### PR TITLE
Update baseUrl in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ const client = createManagementClient({
 | `API Key`        | N/A                                   | **Required** - Management or Subscription API Key. Subscription API Key also works for Management requests            |
 | `environmentId`     | N/A                                   | **Required for Management API** - Environment Id                                                                                                   
 | `subscriptionId`       | N/A  | **Required for Subscription API** - Subscription Id
-| `baseUrl`       | https://manage.kontent.ai/v2/projects | Base URL of REST api. Can be useful if you are using custom proxy or for testing purposes                                                                          
+| `baseUrl`       | https://manage.kontent.ai/v2 | Base URL of REST api. Can be useful if you are using custom proxy or for testing purposes                                                                          
 | `retryStrategy` | undefined                             | Retry strategy configuration. If not set, default strategy is used.                                                                                                 |
 | `httpService`   | HttpService                           | Used to inject implementation of `IHttpService` used to make HTTP request across network. Can also be useful for testing purposes by returning specified responses. |
 


### PR DESCRIPTION
### Motivation

It seems the baseUrl in README is incorrect, the baseUrl is defined followingly: https://github.com/kontent-ai/management-sdk-js/blob/1bc0cf9ebe05f7b3d76cc6a2624ab67b3b4145b5/lib/services/base-management-service.class.ts#L21

This is confusing, because it seems that if the user wants to configure the baseUrl, they need to include the `/projects` part, while, in fact, they mustn’t – if they do, any subsequent calls fail.

### Checklist

Irrelevant.

### How to test

If you try to set up the client using the "https://manage.kontent.ai/v2/projects" URL as `baseUrl`, a subsequent call to for example `viewLanguageVariant()` will fail. However, when using just "https://manage.kontent.ai/v2" as `baseUrl`, the call will succeed.
